### PR TITLE
Set up console_scripts mapping for CLI module usage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,10 @@ Installing pyxform from github is easy with pip::
 
 	pip install -e git+https://github.com/medic/pyxform.git@master#egg=pyxform
 
+You can then run xls2xform from the commandline::
+
+	xls2xform-medic path_to_XLSForm output_path
+
 Testing
 =======
 To make sure the install worked out, you can do the following::

--- a/pyxform/xls2xform.py
+++ b/pyxform/xls2xform.py
@@ -31,7 +31,7 @@ def xls2xform_convert(xlsform_path, xform_path):
     return warnings
 
 
-if __name__ == '__main__':
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('path_to_XLSForm')
     parser.add_argument('output_path')
@@ -67,3 +67,7 @@ if __name__ == '__main__':
         for w in warnings:
             print w
         print 'Conversion complete!'
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(
-    name='pyxform',
+    name='pyxform-medic',
     version='0.9.22',
     author='modilabs',
     author_email='info@modilabs.org',
@@ -19,4 +19,9 @@ setup(
         'xlrd==0.8.0',
         'lxml==2.3.4',
     ],
+    entry_points={
+        'console_scripts': [
+            'xls2xform-medic=pyxform.xls2xform:main',
+        ],
+    },
 )


### PR DESCRIPTION
This change allows running xls2xform after doing `pip install` using:
```
$ xls2xform-medic
```